### PR TITLE
ENH: Add ShapePopulationViewer dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,7 @@ set(EXTENSION_DEPENDS
   ModelToModelDistance
   PickAndPaintExtension
   Q3DC
-  # ShapePopulationViewer
+  ShapePopulationViewer
   # ShapeVariationAnalyzer
   # SPHARM-PDM
   ) # Specified as a list or 'NA' if any


### PR DESCRIPTION
ExtensionsIndex has been updated to include recent fixes.
See https://github.com/Slicer/ExtensionsIndex/pull/1696