### PR TITLE
README: Add list of extensions with GitHub and CDash links

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,5 +2,54 @@
 
 SlicerCMF is the dissemination vehicle of powerful dental image analysis methodology based on 3D Slicer open-source software. SlicerCMF supports patient-specific decision making and assessment of the disease progression via registration of serial images.
 
-Website: https://cmf.slicer.org/
+For more information, see https://cmf.slicer.org/
+
+## Dependencies
+
+SlicerCMF extension depends on other extensions. This means that installing SlicerCMF automatically
+install these.
+
+* Click on the _Extension Name_ link to browse the extension GitHub repository and report issues
+  specific to that extension.
+
+* Click on the _Quality Assurance Dashboard_ link to learn about the extension
+  build, test or packaging status.
+
+| Extension Name                                        | Quality Assurance Dashboard            |
+|-------------------------------------------------------|----------------------------------------|
+| [AnglePlanesExtension][gh-AnglePlanesExtension]       | [cdash][cdash-AnglePlanesExtension]    |
+| [BoneTextureExtension][gh-BoneTextureExtension]       | [cdash][cdash-BoneTextureExtension]    |
+| [CMFreg][gh-CMFreg]                                   | [cdash][cdash-CMFreg]                  |
+| [EasyClip][gh-EasyClip]                               | [cdash][cdash-EasyClip]                |
+| [MeshStatisticsExtension][gh-MeshStatisticsExtension] | [cdash][cdash-MeshStatisticsExtension] |
+| [MeshToLabelMap][gh-MeshToLabelMap]                   | [cdash][cdash-MeshToLabelMap]          |
+| [ModelToModelDistance][gh-ModelToModelDistance]       | [cdash][cdash-ModelToModelDistance]    |
+| [PickAndPaintExtension][gh-PickAndPaintExtension]     | [cdash][cdash-PickAndPaintExtension]   |
+| [Q3DC][gh-Q3DC]                                       | [cdash][cdash-Q3DC]                    |
+| [ShapePopulationViewer][gh-ShapePopulationViewer]     | [cdash][cdash-ShapePopulationViewer]   |
+| [ShapeVariationAnalyzer][gh-ShapeVariationAnalyzer]   | [cdash][cdash-ShapeVariationAnalyzer]  |
+
+[gh-AnglePlanesExtension]: https://github.com/DCBIA-OrthoLab/AnglePlanes-Extension
+[gh-BoneTextureExtension]: https://github.com/Kitware/BoneTextureExtension
+[gh-CMFreg]: https://github.com/DCBIA-OrthoLab/CMFreg
+[gh-EasyClip]: https://github.com/DCBIA-OrthoLab/EasyClip-Extension
+[gh-MeshStatisticsExtension]: https://github.com/DCBIA-OrthoLab/MeshStatisticsExtension
+[gh-MeshToLabelMap]: https://github.com/NIRALUser/MeshToLabelMap
+[gh-ModelToModelDistance]: https://github.com/NIRALUser/3DMetricTools
+[gh-PickAndPaintExtension]: https://github.com/DCBIA-OrthoLab/PickAndPaintExtension
+[gh-Q3DC]: https://github.com/DCBIA-OrthoLab/Q3DCExtension
+[gh-ShapePopulationViewer]: https://github.com/NIRALUser/ShapePopulationViewer
+[gh-ShapeVariationAnalyzer]: https://github.com/DCBIA-OrthoLab/ShapeVariationAnalyzer
+
+[cdash-AnglePlanesExtension]: http://slicer.cdash.org/index.php?project=SlicerPreview&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=AnglePlanesExtension
+[cdash-BoneTextureExtension]: http://slicer.cdash.org/index.php?project=SlicerPreview&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=BoneTexture
+[cdash-CMFreg]: http://slicer.cdash.org/index.php?project=SlicerPreview&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=CMFreg
+[cdash-EasyClip]: http://slicer.cdash.org/index.php?project=SlicerPreview&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=EasyClip
+[cdash-MeshStatisticsExtension]: http://slicer.cdash.org/index.php?project=SlicerPreview&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=MeshStatisticsExtension
+[cdash-MeshToLabelMap]: http://slicer.cdash.org/index.php?project=SlicerPreview&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=MeshToLabelMap
+[cdash-ModelToModelDistance]: http://slicer.cdash.org/index.php?project=SlicerPreview&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=ModelToModelDistance
+[cdash-PickAndPaintExtension]: http://slicer.cdash.org/index.php?project=SlicerPreview&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=PickAndPaintExtension
+[cdash-Q3DC]: http://slicer.cdash.org/index.php?project=SlicerPreview&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=Q3DC
+[cdash-ShapePopulationViewer]: http://slicer.cdash.org/index.php?project=SlicerPreview&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=ShapePopulationViewer
+[cdash-ShapeVariationAnalyzer]: http://slicer.cdash.org/index.php?project=SlicerPreview&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=ShapeVariationAnalyzer
 


### PR DESCRIPTION
After integrating these changes, the README will include the following table:

![image](https://user-images.githubusercontent.com/219043/87097833-065b4280-c214-11ea-9db0-f2c8e22b8afd.png)



