### PR TITLE
Add missing CMFreg modules to the SlicerCMF index

### DIFF
--- a/SlicerCMF/CMakeLists.txt
+++ b/SlicerCMF/CMakeLists.txt
@@ -8,6 +8,7 @@ set(MODULE_PYTHON_SCRIPTS
 
 set(MODULE_PYTHON_RESOURCES
   Resources/Icons/${MODULE_NAME}.png
+  Resources/HTML/SlicerCMF/index.html
   )
 
 #-----------------------------------------------------------------------------

--- a/SlicerCMF/Resources/HTML/SlicerCMF/index.html
+++ b/SlicerCMF/Resources/HTML/SlicerCMF/index.html
@@ -1,0 +1,84 @@
+<h2>SlicerCMF modules:</h2>
+
+<h3><a href="#ShapePopulationViewer">ShapePopulationViewer</a></h3>
+<p>
+    This module allows to interact with multiple 3D surfaces at the same time. It supports
+    visualization and comparison of 3D surfaces by displaying the associated pointwise
+    data (scalar or vector maps) via customizable colormaps.
+</p>
+
+<h3><a href="#ShapeVariationAnalyzer">ShapeVariationAnalyzer</a></h3>
+<p>
+    This module allows the classification of 3D models, according to their morphological
+    variation. This tool is based on a deep learning neural network. The module is
+    composed of multiple panels to perform the different steps of the process: create the
+    classification groups, compute their average shapes, train the classifier and classify
+    shapes.
+</p>
+
+<h3><a href="#AnglePlanes">Angle Planes</a></h3>
+<p>
+    This module is used to calculate the angle between two planes. The user selects
+    already loaded planes or they can define a plane by using three landmarks.
+</p>
+
+<h3><a href="#BoneTexture">Bone Texture</a></h3>
+<p>
+    This module allows to interact with multiple 3D surfaces at the same time. It supports
+    visualization and comparison of 3D surfaces by displaying the associated pointwise
+    data (scalar or vector maps) via customizable colormaps.
+</p>
+
+<h3><a href="#SurfaceRegistration">Surface Registration</a></h3>
+<p>
+    This module performs region based registration.
+</p>
+
+<h3><a href="#EasyClip">EasyClip</a></h3>
+<p>
+    This module is used to clip and close one or
+    several models according to a predetermined plane. Planes can be saved and reused.
+</p>
+
+<h3><a href="#MeshStatistics">MeshStatistics</a></h3>
+<p>
+    This module computes descriptive statistics (min, max, avg, std, 5th per, 15th per,
+    15th per, 75th per, 85th per and 99th per) on data fields of a model or models. The
+    statistics can be computed over predefined regions (selected with <a
+        href="#PickAndPaint">PickAndPaint</a>) or the entire model.
+</p>
+
+<h3><a href="#MeshToLabelMap">Mesh to Label Map</a></h3>
+<p>
+    This module can converts a model into a binary segmentation image volume.
+</p>
+
+<h3><a href="#ModelToModelDistance">Model to Model Distance</a></h3>
+<p>
+    This module computes a point by point distance between two models.
+</p>
+
+<h3><a href="#PickAndPaint">Pick and Paint</a></h3>
+<p>
+    This module selects a region of interest (ROI) in a model or models. The user selects
+    a landmark and a number of vertices to define the size of the ROI, and this
+    information gets propagated to the rest of the models in case of having multiple ones.
+</p>
+
+<h3><a href="#Q3DC">Q3DC</a></h3>
+<p>
+    This module allows to perform head measurements used in craniofacial surgery (called
+    Quantitative 3D Cephalometrics). Using placed fiducials, the module allows users to
+    compute 2D angles: Yaw, Pitch and Roll; and decompose the 3D distance into the three
+    different components: R-L , A-P and S-I. It is possible to compute the middle point
+    between two fiducials and export the values.
+</p>
+
+<h3><a href="#SurfaceRegistration">CMFreg Surface Registration</a></h3>
+<p>
+    This module allows the user to compute and apply transformations (registration)
+    between two 3D models (VTK file). The registration can be computed using the entire
+    mesh of both models (Surface Registration), just a region of interest (ROI
+    Registration) on each model, or two fiducial lists which can be projected on the
+    meshes (Fiducial Registration).
+</p>

--- a/SlicerCMF/Resources/HTML/SlicerCMF/index.html
+++ b/SlicerCMF/Resources/HTML/SlicerCMF/index.html
@@ -74,11 +74,34 @@
     between two fiducials and export the values.
 </p>
 
-<h3><a href="#SurfaceRegistration">CMFreg Surface Registration</a></h3>
+<h3><a href="#SurfaceRegistration">Surface Registration</a></h3>
 <p>
     This module allows the user to compute and apply transformations (registration)
     between two 3D models (VTK file). The registration can be computed using the entire
     mesh of both models (Surface Registration), just a region of interest (ROI
     Registration) on each model, or two fiducial lists which can be projected on the
     meshes (Fiducial Registration).
+</p>
+
+<h3><a href="#NonGrowing">Image Registration (NonGrowing)</a></h3>
+<p>
+    This module allows the user to compute and apply transformations (registration)
+    between two 3D volumes. The registration can use a one-label segmentation image to
+    define a region of interest on each model.
+</p>
+
+<h3><a href="#Growing">Image Registration (Growing)</a></h3>
+<p>
+    This module provides additional voxel-based registration options in addition to the
+    functionality provided by the <a href="#NonGrowing">NonGrowing</a> module.
+</p>
+
+<h3>CMFreg Utilities</h3>
+
+<p>
+    <a href="#ApplyMatrix">ApplyMatrix</a> &mdash;
+    <a href="#Downsize">Downsize</a> &mdash;
+    <a href="#LabelAddition">LabelAddition</a> &mdash;
+    <a href="#LabelExtraction">LabelExtraction</a> &mdash;
+    <a href="#MaskCreation">MaskCreation</a>
 </p>

--- a/SlicerCMF/SlicerCMF.py
+++ b/SlicerCMF/SlicerCMF.py
@@ -1,8 +1,9 @@
 import os
-import unittest
-import vtk, qt, ctk, slicer
+
+import qt
+import slicer
 from slicer.ScriptedLoadableModule import *
-import logging
+
 
 #
 # SlicerCMF
@@ -42,35 +43,23 @@ class SlicerCMFWidget(ScriptedLoadableModuleWidget):
 
     # Instantiate and connect widgets ...
 
-    text = """
-<br>
-<u>SlicerCMF modules:</u><br>
-<p style="margin: 1%  ">
-<a href="#ShapePopulationViewer"><b>ShapePopulationViewer</b></a>: This module allows to interact with multiple 3D surfaces at the same time. It supports visualization and comparison of 3D surfaces by displaying the associated pointwise data (scalar or vector maps) via customizable colormaps.<br><br>
-<a href="#ShapeVariationAnalyzer"><b>ShapeVariationAnalyzer</b></a>: This module allows the classification of 3D models, according to their morphological variation. This tool is based on a deep learning neural network. The module is composed of multiple panels to perform the different steps of the process: create the classification groups, compute their average shapes, train the classifier and classify shapes.s<br><br>
-<a href="#AnglePlanes"><b>Angle Planes</b></a>: This module is used to calculate the angle between two planes. The user selects already loaded planes or they can define a plane by using three landmarks.<br><br>
-<a href="#BoneTexture"><b>Bone Texture</b></a>: This module allows to interact with multiple 3D surfaces at the same time. It supports visualization and comparison of 3D surfaces by displaying the associated pointwise data (scalar or vector maps) via customizable colormaps.<br><br>
-<a href="#SurfaceRegistration"><b>Surface Registration</b></a>: This module performs region based registration<br><br>
-<a href="#EasyClip"><b>EasyClip</b></a>: This module is used to clip and close one or several models according to a predetermined plane. Planes can be saved and reused.<br><br>
-<a href="#MeshStatistics"><b>MeshStatistics</b></a>: This module computes descriptive statistics (min, max, avg, std, 5th per, 15th per, 15th per, 75th per, 85th per and 99th per) on data fields of a model or models. The statistics can be computed over predefined regions (selected with <a href="#PickAndPaint">PickAndPaint</a>) or the entire model.<br><br>
-<a href="#MeshToLabelMap"><b>MeshToLabelMap</b></a>: This module can converts a model into a binary segmentation image volume.<br><br>
-<a href="#ModelToModelDistance"><b>ModelToModelDistance</b></a>: This module computes a point by point distance between two models.<br><br>
-<a href="#PickAndPaint"><b>PickAndPaint</b></a>: This module selects a region of interest (ROI) in a model or models. The user selects a landmark and a number of vertices to define the size of the ROI, and this information gets propagated to the rest of the models in case of having multiple ones.<br><br>
-<a href="#Q3DC"><b>Q3DC</b></a>: This module allows to perform head measurements used in craniofacial surgery (called Quantitative 3D Cephalometrics). Using placed fiducials, the module allows users to compute 2D angles: Yaw, Pitch and Roll; and decompose the 3D distance into the three different components: R-L , A-P and S-I. It is possible to compute the middle point between two fiducials and export the values.<br><br>
-<a href="#SurfaceRegistration"><b>CMFreg</b></a>: This module allows the user to compute and apply transformations (registration) between two 3D models (VTK file). The registration can be computed using the entire mesh of both models (Surface Registration), just a region of interest (ROI Registration) on each model, or two fiducial lists which can be projected on the meshes (Fiducial Registration).<br><br>
-</p>
-    """
+    indexPath = self.resourcePath('HTML/SlicerCMF/index.html')
+    url = qt.QUrl.fromLocalFile(indexPath)
 
     modulesTextBrowser = qt.QTextBrowser()
-    modulesTextBrowser.setHtml(text)
-    modulesTextBrowser.setMinimumHeight(400)
+    modulesTextBrowser.setSource(url)
     modulesTextBrowser.connect('anchorClicked(QUrl)', self.onAnchorClicked)
+
+    sp = qt.QSizePolicy()
+    sp.setVerticalPolicy(qt.QSizePolicy.Expanding)
+    sp.setHorizontalPolicy(qt.QSizePolicy.Expanding)
+    sp.setVerticalStretch(1)
+    sp.setHorizontalStretch(1)
+
+    modulesTextBrowser.setSizePolicy(sp)
 
     self.modulesTextBrowser = modulesTextBrowser
     self.layout.addWidget(self.modulesTextBrowser)
-
-    # Add vertical spacer
-    self.layout.addStretch(1)
 
   def cleanup(self):
     pass
@@ -78,3 +67,7 @@ class SlicerCMFWidget(ScriptedLoadableModuleWidget):
   def onAnchorClicked(self, url):
       moduleName = url.fragment()
       slicer.util.selectModule(moduleName)
+
+  def resourcePath(self, filename):
+    scriptedModulesPath = os.path.dirname(slicer.util.modulePath(self.moduleName))
+    return os.path.join(scriptedModulesPath, 'Resources', filename)


### PR DESCRIPTION
This change adds the missing CMFreg modules to the SlicerCMF module description.

- NonGrowing
- Growing
- ApplyMatrix
- Downsize
- LabelAddition
- LabelExtraction
- MaskCreation

As there are no descriptions for these modules in their documentation, I describe the NonGrowing and Growing modules to the best of my ability. Since the rest of the modules are smaller utilities, I group them together and leave them without a description. I'll paste my descriptions here for convenience.

> ### Image Registration (NonGrowing):
> 
> This module allows the user to compute and apply transformations (registration) between two 3D volumes. The registration can use a one-label segmentation image to define a region of interest on each model.
> 
> ### Image Registration (Growing):
> 
> This module provides additional voxel-based registration options in addition to the functionality provided by the NonGrowing module.

I've also made some changes to how the html is stored and displayed:

- The html content is in a separate resource file.
- I've rearranged the HTML tags to be easier to understand (separate `<p>` for each paragraph; use `<h3>` for headings)
- I've tweaked the resize policy of the widget so that the content spans the entire module widget. Screenshot below.

![cmf index](https://user-images.githubusercontent.com/10702931/123864936-4e79e600-d8f9-11eb-8933-6414ba6ce57f.png)

Since I'm changing the resource files I want to make sure this change works on MacOS before we close issue #22.